### PR TITLE
Documented contract for find-or-create-brush was incorrect.

### DIFF
--- a/draw-doc/scribblings/draw/brush-list-class.scrbl
+++ b/draw-doc/scribblings/draw/brush-list-class.scrbl
@@ -17,7 +17,7 @@ Creates an empty brush list.
 
 }
 
-@defmethod*[([(find-or-create-brush [color (is-a?/c color%)]
+@defmethod*[([(find-or-create-brush [color (or/c string? (is-a?/c color%))]
                                     [style (or/c 'transparent 'solid 'opaque
                                                  'xor 'hilite 'panel 
                                                  'bdiagonal-hatch 'crossdiag-hatch 


### PR DESCRIPTION
Seeing as the docs say this will do the same thing as creating a brush, should this not also take the optional arguments for `stipple`, `gradient`, and `transformation`? I know the functionality isn't there right now, but I think it should be.