### PR TITLE
add deftech for 'font weight'

### DIFF
--- a/draw-doc/scribblings/draw/draw-contracts.scrbl
+++ b/draw-doc/scribblings/draw/draw-contracts.scrbl
@@ -28,18 +28,8 @@ and functions.
 }
 
 @defthing[font-weight/c flat-contract?]{
-  Recognizes font weights. Corresponds to the @racket[_weight]
+  Recognizes @tech{font weights}. Corresponds to the @racket[_weight]
   initialization argument of the @racket[font%] class.
-
-  Equivalent to the following definition:
-  @racketblock[(or/c (integer-in 100 1000)
-                     'thin 'ultralight 'light 'semilight 'book 'normal
-                     'medium 'semibold 'bold 'ultrabold 'heavy 'ultraheavy)]
-
-  @history[#:changed "1.14" @elem{Changed to allow integer values and the symbols @racket['thin],
-                                  @racket['ultralight], @racket['semilight], @racket['book],
-                                  @racket['medium], @racket['semibold], @racket['ultrabold],
-                                  @racket['heavy], and @racket['ultraheavy].}]
 }
 
 @defthing[font-smoothing/c flat-contract?]{

--- a/draw-doc/scribblings/draw/font-class.scrbl
+++ b/draw-doc/scribblings/draw/font-class.scrbl
@@ -56,9 +56,10 @@ A @defterm{font} is an object which determines the appearance of text,
  @item{@indexed-racket['italic]}
  ]}
 
-@item{weight --- The weight of the font, an exact integer between @racket[100] and @racket[1000],
-                 inclusive, or one of:
+@item{@deftech[#:key "font weight"]{weight} ---
+ The weight of the font, one of:
  @itemize[
+ @item{@racket[(integer-in 100 1000)]}
  @item{@indexed-racket['thin] (equivalent to @racket[100])}
  @item{@indexed-racket['ultralight] (equivalent to @racket[200])}
  @item{@indexed-racket['light] (equivalent to @racket[300])}
@@ -71,7 +72,13 @@ A @defterm{font} is an object which determines the appearance of text,
  @item{@indexed-racket['ultrabold] (equivalent to @racket[800])}
  @item{@indexed-racket['heavy] (equivalent to @racket[900])}
  @item{@indexed-racket['ultraheavy] (equivalent to @racket[1000])}
- ]}
+ ]
+
+ @history[#:changed "1.14" @elem{Changed to allow integer values and the symbols @racket['thin],
+                                 @racket['ultralight], @racket['semilight], @racket['book],
+                                 @racket['medium], @racket['semibold], @racket['ultrabold],
+                                 @racket['heavy], and @racket['ultraheavy].}]
+ }
 
 @item{underline? --- @racket[#t] for underlined, @racket[#f] for plain.}
 


### PR DESCRIPTION
(I read the comments in #12, thought the docs should explain "100" and "1000", and here we are.)

- - -

Define/provide/document a flat contact for integers that Pango can interpret
as font weights.

This seems like a nice way to:

- explain why Racket expects an integer in [100, 1000]
- document `racket/draw`'s assumptions about Pango
- eventually support other backends --- if `racket/draw` wants to
  draw to HTML canvas, then the font weight contract can be an
  `(or/c css-font-weight? pango-font-weight? ....)`