### PR TITLE
Align both brush and pen drawing in `draw-ellipse`

### DIFF
--- a/draw-lib/racket/draw/private/dc.rkt
+++ b/draw-lib/racket/draw/private/dc.rkt
@@ -1116,7 +1116,7 @@
       (with-cr 
        (check-ok who)
        cr
-       (let ([draw-one (lambda (align-x align-y brush? pen? sub1w sub1h)
+       (let ([draw-one (lambda (brush? pen? sub1w sub1h)
                          (let* ([orig-x x]
                                 [orig-y y]
                                 [x (align-x x)]
@@ -1146,10 +1146,9 @@
                              (cairo_restore cr)
                              (draw cr brush? pen?))))])
          (when (brush-draws?)
-           (draw-one (lambda (x) x) (lambda (y) y) #t #f (lambda (x) x) (lambda (x) x)))
+           (draw-one #t #f (lambda (x) x) (lambda (x) x)))
          (when (pen-draws?)
-           (draw-one (lambda (x) (align-x x)) (lambda (y) (align-y y)) #f #t 
-                     (lambda (x) (sub1w x)) (lambda (x) (sub1h x)))))))
+           (draw-one #f #t (lambda (x) (sub1w x)) (lambda (x) (sub1h x)))))))
 
     (def/public (draw-arc [real? x] [real? y] [nonnegative-real? width] [nonnegative-real? height]
                           [real? start-radians] [real? end-radians])


### PR DESCRIPTION
For some reason, `draw-ellipse` goes out of its way to *not* align coordinates when drawing with the brush, but that doesn’t make a lot of sense. Not only is it weird and inconsistent, it can cause problems where the stroke would actually get drawn inside the boundary of the ellipse, leaving part of the fill peeking out from “under” the edge. Here’s a highly zoomed-in example:

<img width="147" alt="Screen Shot 2020-06-04 at 14 28 31" src="https://user-images.githubusercontent.com/759911/83802598-a7346c00-a670-11ea-9bf0-be9569f905fa.png">

Here, I’ve drawn a circle with a white fill and a grey stroke, superimposed on top of a black line. You can see that the edge of the fill is not fully covered by the stroke, so there’s an extra white fringe.

This PR just aligns both sets of coordinates, which is more consistent and fixes the problem. Here’s the same example with this change:

<img width="173" alt="Screen Shot 2020-06-04 at 14 37 12" src="https://user-images.githubusercontent.com/759911/83802711-e498f980-a670-11ea-99f1-64d88c4e5860.png">