### PR TITLE
Add interface for simple compositing layers to dc<%>

### DIFF
--- a/draw-lib/info.rkt
+++ b/draw-lib/info.rkt
@@ -17,4 +17,4 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.15")
+(define version "1.16")

--- a/draw-lib/racket/draw/private/dc-intf.rkt
+++ b/draw-lib/racket/draw/private/dc-intf.rkt
@@ -33,6 +33,7 @@
         'horizontal-hatch 'vertical-hatch))
 
 (define dc<%>
+  (let ([is-a-dc<%>/c (recursive-contract (is-a?/c dc<%>) #:flat)])
   (interface ()
     [cache-font-metrics-key (->m exact-integer?)]
     [clear (->m void?)]
@@ -65,6 +66,7 @@
                        (and/c real? (not/c negative?))
                        (and/c real? (not/c negative?))
                        void?)]
+    [draw-layer (->*m [is-a-dc<%>/c] [real? real?] void?)]
     [draw-line (->m real? real?
                     real? real?
                     void?)]
@@ -135,6 +137,7 @@
                                                  real? real? real?)
                                        real? real? real? real? real?))]
     [glyph-exists? (->m char? boolean?)]
+    [make-layer (->m is-a-dc<%>/c)]
     [ok? (->m boolean?)]
     [resume-flush (->m void?)]
     [rotate (->m real? void?)]
@@ -177,4 +180,4 @@
     [transform (->m (vector/c real? real? real? real? real? real?)
                     void?)]
     [translate (->m real? real? void?)]
-    [try-color (->m (is-a?/c color%) (is-a?/c color%) void?)]))
+    [try-color (->m (is-a?/c color%) (is-a?/c color%) void?)])))

--- a/draw-lib/racket/draw/private/local.rkt
+++ b/draw-lib/racket/draw/private/local.rkt
@@ -27,6 +27,7 @@
   get-clipping-matrix
   reset-config
   internal-copy
+  draw-owned-layer
 
   ;; region%
   install-region
@@ -59,4 +60,7 @@
   can-combine-text?
   can-mask-bitmap?
   reset-clip
-  get-clear-operator)
+  get-clear-operator
+
+  ;; layer-dc-backend<%>
+  get-owner)

--- a/draw-lib/racket/draw/private/page-dc.rkt
+++ b/draw-lib/racket/draw/private/page-dc.rkt
@@ -103,6 +103,7 @@
      (draw-rectangle x y w h)
      (draw-point x y)
      (draw-line x1 y1 x2 y2)
+     (draw-layer layer [x [y]])
      (clear)
      (erase))
 

--- a/draw-lib/racket/draw/unsafe/cairo.rkt
+++ b/draw-lib/racket/draw/unsafe/cairo.rkt
@@ -56,6 +56,8 @@
 (define-syntax-rule (_cbfun . rest)
   (_fun #:atomic? #t . rest))
 
+(define-cairo cairo_version_string (_cfun -> _string))
+
 (define-cairo cairo_destroy (_cfun _cairo_t -> _void) 
   #:wrap (deallocator))
 


### PR DESCRIPTION
@mflatt This PR is a work-in-progress, as it still needs tests and docs. However, before I write those, I wanted to ask if you think I’m on the right track. Here’s a summary of the API so far:

* We add two new methods to `dc<%>`:

  ```racket
  (make-layer) -> (is-a?/c dc<%>)

  (draw-layer layer [x y]) -> void?
    layer : (is-a?/c dc<%>)
    x : real? = 0
    y : real? = 0
  ```

* `make-layer` creates a new `dc<%>` that inherits its backend configuration, pen, brush, font, text foreground/background, alignment scale, and smoothing from the parent.

* After drawing to the new dc, you can draw it onto the parent dc using `draw-layer`, which applies the current transformation and alpha.

In additional to any general comments you might have about the API, here are the implementation details I’m most unsure about:

1. In `draw-layer`, I don’t do any setup except installing the right smoothing before drawing. I have no idea if I’m missing something.

2. The `record-dc%` implementation seems to work fine, but I’m not totally confident about it.

Finally, here’s an example program that uses layers:

```racket
#lang racket
(require racket/draw)

(define bmp (make-bitmap 400 400))
(define dc (new bitmap-dc% [bitmap bmp]))
(send dc set-background "white")
(send dc clear)
(send dc set-brush "black" 'solid)

(define layer (send dc make-layer))
(send layer draw-rectangle  50  50 250 250)
(send layer draw-rectangle 100 100 250 250)

(send dc set-alpha 0.5)
(send dc draw-layer layer)
(send dc scale 0.5 0.5)
(send dc draw-layer layer 200 200)

(send bmp save-file "/tmp/out.png" 'png)
```

This produces the following output:

![output](https://user-images.githubusercontent.com/759911/84970394-382f2c80-b0e0-11ea-9c22-29afc9cf0ec4.png)
