### PR TITLE
font%: Add support for OpenType feature settings

### DIFF
--- a/draw-doc/scribblings/draw/draw-contracts.scrbl
+++ b/draw-doc/scribblings/draw/draw-contracts.scrbl
@@ -50,6 +50,20 @@ and functions.
   @racketblock[(or/c 'aligned 'unaligned)]
 }
 
+@defthing[font-feature-settings/c flat-contract?]{
+  Recognizes font @tech{OpenType feature settings}. Corresponds to the
+  @racket[_feature-settings] initialization argument of the @racket[font%]
+  class.
+
+  Equivalent to the following definition:
+  @racketblock[(and/c hash-equal?
+                      hash-strong?
+                      (hash/c (and/c string? #px"^[ !#-~]{4}$")
+                              exact-nonnegative-integer?
+                              #:immutable #t))]
+  @history[#:added "1.19"]
+}
+
 @defthing[pen-style/c flat-contract?]{
   Recognizes pen styles. Corresponds
   to the @racket[_style] initialization argument of the

--- a/draw-doc/scribblings/draw/draw-funcs.scrbl
+++ b/draw-doc/scribblings/draw/draw-funcs.scrbl
@@ -114,7 +114,8 @@ or @racket[the-color-database].}
                                                  'smoothed 'unsmoothed) 
                                  'default]
                     [#:size-in-pixels? size-in-pixels? any/c #f]
-                    [#:hinting hinting (or/c 'aligned 'unaligned) 'aligned])
+                    [#:hinting hinting (or/c 'aligned 'unaligned) 'aligned]
+                    [#:feature-settings feature-settings font-feature-settings/c (hash)])
          (is-a?/c font%)]{
 
 Creates a @racket[font%] instance. This procedure provides an
@@ -125,7 +126,8 @@ equivalent but more convenient interface compared to using
          #:changed "1.14" @elem{Changed @racket[weight] to allow integer values and the symbols
                                 @racket['thin], @racket['ultralight], @racket['semilight],
                                 @racket['book], @racket['medium], @racket['semibold],
-                                @racket['ultrabold], @racket['heavy], and @racket['ultraheavy].}]}
+                                @racket['ultrabold], @racket['heavy], and @racket['ultraheavy].}
+         #:changed "1.19" @elem{Added the optional @racket[feature-settings] argument.}]}
 
 
 @defproc[(make-monochrome-bitmap [width exact-positive-integer?]

--- a/draw-doc/scribblings/draw/font-class.scrbl
+++ b/draw-doc/scribblings/draw/font-class.scrbl
@@ -5,7 +5,7 @@
 
 A @defterm{font} is an object which determines the appearance of text,
  primarily when drawing text to a device context. A font is determined
- by seven properties:
+ by eight properties:
 
 @itemize[
 
@@ -104,6 +104,17 @@ A @defterm{font} is an object which determines the appearance of text,
    @item{@indexed-racket['unaligned] --- disables rounding}
  ]}
 
+@item{@deftech[#:key "OpenType feature settings"]{feature settings} ---
+        A hash of @hyperlink["https://practicaltypography.com/opentype-features.html"]{
+        OpenType feature} settings to enable or disable optional typographic
+        features of OpenType fonts. Each entry in the hash maps a four-letter
+        OpenType feature tag to its desired value. For boolean OpenType features,
+        a value of @racket[0] means “disabled” and a value of @racket[1] means
+        “enabled”; for other features, the meaning of the value varies (and may
+        even depend on the font itself).
+
+        @history[#:added "1.19"]}
+
 ]
 
 To avoid creating multiple fonts with the same characteristics, use
@@ -117,7 +128,8 @@ See also
          #:changed "1.14" @elem{Changed ``weight'' to allow integer values and the symbols
                                 @racket['thin], @racket['ultralight], @racket['semilight],
                                 @racket['book], @racket['medium], @racket['semibold],
-                                @racket['ultrabold], @racket['heavy], and @racket['ultraheavy].}]
+                                @racket['ultrabold], @racket['heavy], and @racket['ultraheavy].}
+         #:changed "1.19" @elem{Added the ``feature settings'' property to control OpenType features.}]
 
 
 @defconstructor*/make[(()
@@ -128,7 +140,8 @@ See also
                         [underline? any/c #f]
                         [smoothing font-smoothing/c 'default]
                         [size-in-pixels? any/c #f]
-                        [hinting font-hinting/c 'aligned])
+                        [hinting font-hinting/c 'aligned]
+                        [feature-settings font-feature-settings/c (hash)])
                        ([size (real-in 0.0 1024.0)]
                         [face string?]
                         [family font-family/c]
@@ -137,7 +150,8 @@ See also
                         [underline? any/c #f]
                         [smoothing font-smoothing/c 'default]
                         [size-in-pixels? any/c #f]
-                        [hinting font-hinting/c 'aligned]))]{
+                        [hinting font-hinting/c 'aligned]
+                        [feature-settings font-feature-settings/c (hash)]))]{
 
 When no arguments are provided, creates an instance of the default
  font. If no face name is provided, the font is created without a face
@@ -145,7 +159,7 @@ When no arguments are provided, creates an instance of the default
 
 See @racket[font%] for information about @racket[family],
  @racket[style], @racket[weight], @racket[smoothing],
- @racket[size-in-pixels?], and @racket[hinting].
+ @racket[size-in-pixels?], @racket[hinting], and @racket[feature-settings].
  @racket[font-name-directory<%>].
 
 See also @racket[make-font].
@@ -154,7 +168,8 @@ See also @racket[make-font].
          #:changed "1.14" @elem{Changed @racket[weight] to allow integer values and the symbols
                                 @racket['thin], @racket['ultralight], @racket['semilight],
                                 @racket['book], @racket['medium], @racket['semibold],
-                                @racket['ultrabold], @racket['heavy], and @racket['ultraheavy].}]}
+                                @racket['ultrabold], @racket['heavy], and @racket['ultraheavy].}
+         #:changed "1.19" @elem{Added the optional @racket[feature-settings] argument.}]}
 
 
 @defmethod[(get-face)
@@ -168,6 +183,12 @@ Gets the font's face name, or @racket[#f] if none is specified.
 
 Gets the font's family. See @racket[font%] for information about
 families.
+
+}
+
+@defmethod[(get-feature-settings) font-feature-settings/c]{
+
+Gets the font's @tech{OpenType feature settings}.
 
 }
 

--- a/draw-doc/scribblings/draw/font-list-class.scrbl
+++ b/draw-doc/scribblings/draw/font-list-class.scrbl
@@ -23,7 +23,8 @@ Creates an empty font list.
                                    [underline? any/c #f]
                                    [smoothing (or/c 'default 'partly-smoothed 'smoothed 'unsmoothed) 'default]
                                    [size-in-pixels? any/c #f]
-                                   [hinting (or/c 'aligned 'unaligned) 'aligned])
+                                   [hinting (or/c 'aligned 'unaligned) 'aligned]
+                                   [feature-settings font-feature-settings/c (hash)])
               (is-a?/c font%)]
              [(find-or-create-font [size (real-in 0.0 1024.0)]
                                    [face string?]
@@ -34,11 +35,13 @@ Creates an empty font list.
                                    [underline any/c #f]
                                    [smoothing (or/c 'default 'partly-smoothed 'smoothed 'unsmoothed) 'default]
                                    [size-in-pixels? any/c #f]
-                                   [hinting (or/c 'aligned 'unaligned) 'aligned])
+                                   [hinting (or/c 'aligned 'unaligned) 'aligned]
+                                   [feature-settings font-feature-settings/c (hash)])
               (is-a?/c font%)])]{
 
 Finds an existing font in the list or creates a new one (that is
  automatically added to the list). The arguments are the same as for
  creating a @racket[font%] instance.
 
-@history[#:changed "1.4" @elem{Changed @racket[size] to allow non-integer and zero values.}]}}
+@history[#:changed "1.4" @elem{Changed @racket[size] to allow non-integer and zero values.}
+         #:changed "1.19" @elem{Added the optional @racket[feature-settings] argument.}]}}

--- a/draw-lib/info.rkt
+++ b/draw-lib/info.rkt
@@ -18,7 +18,7 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.18")
+(define version "1.19")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/draw-lib/racket/draw.rkt
+++ b/draw-lib/racket/draw.rkt
@@ -73,7 +73,8 @@
          font-weight/c
          font-style/c
          font-smoothing/c
-         font-hinting/c)
+         font-hinting/c
+         font-feature-settings/c)
 
 (provide/contract [color%            color%/c]
                   [point%            point%/c]

--- a/draw-lib/racket/draw/private/dc.rkt
+++ b/draw-lib/racket/draw/private/dc.rkt
@@ -1485,7 +1485,7 @@
           (cairo_translate cr x y)
           (cairo_rotate cr (- angle)))
         (let ([desc (get-pango font)]
-              [attrs (font->pango-attrs font)]
+              [attrs (send font get-pango-attrs)]
               [force-hinting (case (font->hinting font)
                                [(aligned) round]
                                [else values])]
@@ -2128,7 +2128,6 @@
 
     (define/private (get-font-metric cr sel s-sel)
       (let* ([desc (get-pango font)]
-	     [attrs (send font get-pango-attrs)]
 	     [index (get-smoothing-index font)]
 	     [context (get-context cr index font current-xform)]
 	     [fontmap (get-font-map index current-xform)]

--- a/draw-lib/racket/draw/private/font-syms.rkt
+++ b/draw-lib/racket/draw/private/font-syms.rkt
@@ -2,12 +2,14 @@
 
 ;; font utilities for contracts
 
-(require racket/contract/base)
+(require racket/contract/base
+         racket/match)
 
 (provide family-symbol? style-symbol? weight-symbol? 
          smoothing-symbol? hinting-symbol?
          font-family/c font-weight/c font-style/c
-         font-smoothing/c font-hinting/c)
+         font-smoothing/c font-hinting/c
+         font-feature-settings/c)
 
 (define (family-symbol? s)
   (memq s '(default decorative roman script
@@ -39,3 +41,22 @@
                                'smoothed 'unsmoothed))
 (define font-hinting/c   (or/c 'aligned 'unaligned))
 
+;; Note: The Pango documentation for `pango_attr_font_features_new` says that it
+;; accepts OpenType font features as a string with “the syntax of the CSS
+;; font-feature-settings property”. In turn, the CSS spec says that a tag string
+;; must be exactly 4 characters in the “U+20–7E codepoint range”.
+;;
+;; However, in reality, Pango passes this string to HarfBuzz’s
+;; `hb_feature_from_string` function, which does not implement CSS string
+;; escapes. This means it’s impossible to correctly format a feature string for
+;; a feature with a tag like ‘a'"b’ because there is no way to properly escape
+;; both #\' and #\".
+;;
+;; However, in practice, all OpenType feature tags are strictly alphanumeric,
+;; anyway. So we just disallow the " character, which avoids the problem.
+(define font-feature-tag/c (and/c string? #px"^[ !#-~]{4}$"))
+(define font-feature-settings/c (and/c hash-equal?
+                                       hash-strong?
+                                       (hash/c font-feature-tag/c
+                                               exact-nonnegative-integer?
+                                               #:immutable #t)))

--- a/draw-lib/racket/draw/private/record-dc.rkt
+++ b/draw-lib/racket/draw/private/record-dc.rkt
@@ -339,7 +339,8 @@
         (send f get-underlined)
         (send f get-smoothing)
         (send f get-size-in-pixels)
-        (send f get-hinting)))
+        (send f get-hinting)
+        (send f get-feature-settings)))
 
 (define (unconvert-font l)
   (apply make-object font% l))

--- a/draw-lib/racket/draw/unsafe/pango.rkt
+++ b/draw-lib/racket/draw/unsafe/pango.rkt
@@ -253,6 +253,9 @@
   #:wrap (allocator pango_attribute_destroy))
 (define-pango pango_attr_fallback_new (_pfun _bool -> PangoAttribute)
   #:wrap (allocator pango_attribute_destroy))
+(define-pango pango_attr_font_features_new (_pfun _string -> PangoAttribute)
+  #:wrap (allocator pango_attribute_destroy)
+  #:make-fail make-not-available)
 
 (define-pango pango_attr_foreground_new (_pfun _uint16 _uint16 _uint16 -> PangoAttribute)
   #:wrap (allocator pango_attribute_destroy))


### PR DESCRIPTION
This PR adds a new `feature-settings` argument to the constructor for `font%`, which allows enabling or disabling [OpenType features](https://practicaltypography.com/opentype-features.html) for any fonts that support them (such as ligatures and stylistic sets, among many other things). This corresponds to the [CSS `font-feature-settings` property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings).