### PR TITLE
Allow `make-font` to look up a font in a `font-list%` instance

### DIFF
--- a/draw-doc/scribblings/draw/draw-funcs.scrbl
+++ b/draw-doc/scribblings/draw/draw-funcs.scrbl
@@ -115,19 +115,37 @@ or @racket[the-color-database].}
                                  'default]
                     [#:size-in-pixels? size-in-pixels? any/c #f]
                     [#:hinting hinting (or/c 'aligned 'unaligned) 'aligned]
-                    [#:feature-settings feature-settings font-feature-settings/c (hash)])
+                    [#:feature-settings feature-settings font-feature-settings/c (hash)]
+                    [#:font-list font-list (or/c (is-a?/c font-list%) #f) (current-font-list)])
          (is-a?/c font%)]{
 
-Creates a @racket[font%] instance. This procedure provides an
-equivalent but more convenient interface compared to using
-@racket[make-object] with @racket[font%].
+Finds or creates a @racket[font%] instance.
+
+When @racket[font-list] is @racket[#f], @racket[make-font] creates a
+new font using @racket[make-object] with @racket[font%]. Otherwise,
+when @racket[font-list] is a @racket[font-list%] instance,
+@racket[make-font] finds or creates a font using its
+@method[font-list% find-or-create-font] method. In both cases,
+@racket[make-font] merely provides a more convenient interface.
 
 @history[#:changed "1.4" @elem{Changed @racket[size] to allow non-integer and zero values.}
          #:changed "1.14" @elem{Changed @racket[weight] to allow integer values and the symbols
                                 @racket['thin], @racket['ultralight], @racket['semilight],
                                 @racket['book], @racket['medium], @racket['semibold],
                                 @racket['ultrabold], @racket['heavy], and @racket['ultraheavy].}
-         #:changed "1.19" @elem{Added the optional @racket[feature-settings] argument.}]}
+         #:changed "1.19" @elem{Added the optional @racket[feature-settings] and
+                                @racket[font-list] arguments.}]}
+
+
+@defparam[current-font-list font-list (or/c (is-a?/c font-list%) #f)
+          #:value #f]{
+
+A parameter that determines the default value for the
+@racket[#:font-list] argument to @racket[make-font]. Defaults to
+@racket[#f], but see @racket[the-font-list] for a possible
+alternative value.
+                      
+@history[#:added "1.19"]}
 
 
 @defproc[(make-monochrome-bitmap [width exact-positive-integer?]

--- a/draw-doc/scribblings/draw/font-list-class.scrbl
+++ b/draw-doc/scribblings/draw/font-list-class.scrbl
@@ -43,5 +43,7 @@ Finds an existing font in the list or creates a new one (that is
  automatically added to the list). The arguments are the same as for
  creating a @racket[font%] instance.
 
+See also @racket[make-font] and @racket[current-font-list].
+
 @history[#:changed "1.4" @elem{Changed @racket[size] to allow non-integer and zero values.}
          #:changed "1.19" @elem{Added the optional @racket[feature-settings] argument.}]}}

--- a/draw-lib/racket/draw.rkt
+++ b/draw-lib/racket/draw.rkt
@@ -27,6 +27,7 @@
          font-list% the-font-list make-font
          font-name-directory<%> the-font-name-directory
 	 (contract-out
+          [current-font-list (parameter/c (or/c (is-a?/c font-list%) #f))]
           [the-pen-list (instanceof/c pen-list%/c)]
           [the-brush-list (instanceof/c brush-list%/c)])
          dc<%>

--- a/draw-lib/racket/draw/private/font.rkt
+++ b/draw-lib/racket/draw/private/font.rkt
@@ -12,7 +12,7 @@
          "lock.rkt")
 
 (provide font%
-         font-list% the-font-list
+         font-list% the-font-list current-font-list
          make-font
          family-symbol? style-symbol? smoothing-symbol? hinting-symbol?
          get-face-list
@@ -403,6 +403,8 @@
               family-name])))))
    string<?))
 
+(define current-font-list (make-parameter #f))
+
 (define (make-font #:size [size 12.0]
                    #:face [face #f]
                    #:family [family 'default]
@@ -412,7 +414,8 @@
                    #:smoothing [smoothing 'default]
                    #:size-in-pixels? [size-in-pixels? #f]
                    #:hinting [hinting 'aligned]
-                   #:feature-settings [feature-settings (hash)])
+                   #:feature-settings [feature-settings (hash)]
+                   #:font-list [font-list (current-font-list)])
   (unless (and (real? size) (<= 0.0 size 1024.0)) (raise-type-error 'make-font "real number in [0.0, 1024.0]" size))
   (unless (or (not face) (string? face)) (raise-type-error 'make-font "string or #f" face))
   (unless (family-symbol? family) (raise-type-error 'make-font "family-symbol" family))
@@ -420,4 +423,8 @@
   (unless (font-weight/c weight) (raise-argument-error 'make-font "font-weight/c" weight))
   (unless (smoothing-symbol? smoothing) (raise-type-error 'make-font "smoothing-symbol" smoothing))
   (unless (hinting-symbol? hinting) (raise-type-error 'make-font "hinting-symbol" hinting))
-  (make-object font% size face family style weight underlined? smoothing size-in-pixels? hinting feature-settings))
+  (unless (or (not font-list) (is-a? font-list font-list%))
+    (raise-argument-error 'make-font "(or/c (is-a?/c font-list%) #f)" font-list))
+  (if font-list
+      (send font-list find-or-create-font size face family style weight underlined? smoothing size-in-pixels? hinting feature-settings)
+      (make-object font% size face family style weight underlined? smoothing size-in-pixels? hinting feature-settings)))

--- a/draw-test/tests/racket/draw/font.rkt
+++ b/draw-test/tests/racket/draw/font.rkt
@@ -1,0 +1,26 @@
+#lang racket/base
+
+(require racket/draw
+         racket/class
+         rackunit)
+
+(test-case
+ "make-font is generative without a #:font-list argument"
+ (check-not-eq? (make-font) (make-font))
+ (check-not-eq? (make-font) (make-font #:font-list the-font-list)))
+
+(test-case
+ "make-font caches fonts when given a #:font-list argument"
+ (check-eq? (make-font #:font-list the-font-list)
+            (make-font #:font-list the-font-list)))
+
+(test-case
+ "make-font with different #:font-list arguments returns different fonts"
+ (define other-font-list (new font-list%))
+ (check-not-eq? (make-font #:font-list the-font-list)
+                (make-font #:font-list other-font-list)))
+
+(test-case
+ "make-font caches fonts by default when current-font-list is set"
+ (parameterize ([current-font-list the-font-list])
+   (check-eq? (make-font) (make-font))))


### PR DESCRIPTION
This PR allows the dramatically more convenient interface of `make-font` to be combined with the caching of `font-list%`. In addition to adding a `#:font-list` argument to `make-font`, it also adds a new `current-font-list` parameter that controls its default value (initially `#f`).

Though adding a separate `find-or-make-font` function might be nominally slightly clearer, allowing `make-font` to perform both tasks makes it possible for functions that create fonts to be optionally configured to look up the font in a font list, which is a useful thing to do. The `current-font-list` parameter conveniently allows existing code that creates fonts via `make-font` to be automatically configured to use a font list, even if they were written long before this change.