### PR TITLE
Fix #47

### DIFF
--- a/draw-lib/racket/draw/private/bitmap-dc.rkt
+++ b/draw-lib/racket/draw/private/bitmap-dc.rkt
@@ -186,6 +186,14 @@
            (when (eq? s 'unsmoothed) (set-smoothing 'unsmoothed))
            (set-transformation t)))))
 
+    (define/override (get-text-extent s
+                                      [use-font (get-font)]
+                                      [combine? #f]
+                                      [offset 0])
+      (if (internal-get-bitmap)
+          (super get-text-extent s use-font combine? offset)
+          (send (get-temp-bitmap-dc) get-text-extent s use-font combine? offset)))
+
     (def/override (get-char-width)
       (if (internal-get-bitmap)
           (super get-char-width)

--- a/draw-test/tests/racket/draw/dc.rkt
+++ b/draw-test/tests/racket/draw/dc.rkt
@@ -965,5 +965,17 @@
 (test #f 'undef-bitmap-dc (impersonator? (new bitmap-dc%)))
 
 ;; ----------------------------------------
+;; No error when bitmap is uninstalled
+
+(let ()
+  (define dc (new bitmap-dc%))
+  (define cw (send dc get-char-width))
+  (define ch (send dc get-char-height))
+  (define-values (w h d a) (send dc get-text-extent "foo"))
+  (test #t
+        'uninstalled-bitmap
+        (andmap real? (list cw ch w h d a))))
+
+;; ----------------------------------------
 
 (report-errs)


### PR DESCRIPTION
It seems like `bitmap-dc%` was missing an override. (Use of rest args is to avoid duplicating the default args of `get-text-extent` in the overriding method).