### PR TITLE
use `ffi/unsafe/runtime-lib`

### DIFF
--- a/draw-lib/racket/draw/private/libs.rkt
+++ b/draw-lib/racket/draw/private/libs.rkt
@@ -1,56 +1,46 @@
 #lang racket/base
-(require ffi/unsafe
-         racket/runtime-path
+(require ffi/unsafe/runtime-lib
          ffi/winapi
-         setup/cross-system
          (for-syntax racket/base
-                     ffi/winapi
-                     setup/cross-system))
+                     syntax/parse/pre
+                     ffi/winapi))
 
-(provide define-runtime-lib
+(provide (rename-out [define-runtime-lib/legacy
+                       define-runtime-lib])
          win64?
          (for-syntax win64?))
 
-(define-syntax define-runtime-lib
-  ;; the ids macosx unix windows don't appear to be bound here, but I added win32 and win64 anyways
-  (syntax-rules (macosx unix windows win32 win64 ffi-lib)
-    [(_ lib-id
-        [(unix) unix-lib]
-        [(macosx) (ffi-lib mac-lib) ...]
-        [(windows) (ffi-lib windows-lib) ...])
-     (begin
-       (define-runtime-path-list libs
-         #:runtime?-id runtime?
-         (case (if runtime? (system-type) (cross-system-type))
-           [(macosx) '((so mac-lib) ...)]
-           [(unix) null]
-           [(windows) `((so windows-lib) ...)]))
+(begin-for-syntax
+  (define-syntax-class :system-spec
+    #:attributes (modern)
+    #:datum-literals (windows win32 win64 macosx)
+    ;; legacy cases --------------------
+    (pattern (windows)
+             #:attr modern #'windows)
+    (pattern (win32)
+             #:attr modern #'(and windows 32))
+    (pattern (win64)
+             #:attr modern #'(and windows 64))
+    (pattern (macosx)
+             #:attr modern #'macosx)
+    ;; modern cases --------------------
+    (pattern any
+             #:attr modern #'any)))
 
-       (define lib-id
-         (if (null? libs)
-             unix-lib
-             (for/fold ([v #f]) ([lib (in-list libs)])
-               (ffi-lib lib)))))]
-    [(_ lib-id
-        [(unix) unix-lib]
-        [(macosx) (ffi-lib mac-lib) ...]
-        [(win32) (ffi-lib win32-lib) ...]
-        [(win64) (ffi-lib win64-lib) ...])
-     (begin
-       (define-runtime-path-list libs
-         #:runtime?-id runtime?
-         (case (if runtime? (system-type) (cross-system-type))
-           [(macosx) '((so mac-lib) ...)]
-           [(unix) null]
-           [(windows)
-            (if win64?
-                `((so win64-lib) ...)
-                `((so win32-lib) ...))]))
-
-       (define lib-id
-         (if (null? libs)
-             unix-lib
-             (for/fold ([v #f]) ([lib (in-list libs)])
-               (ffi-lib lib)))))]))
-
-
+(define-syntax (define-runtime-lib/legacy stx)
+  (syntax-parse stx
+    #:literals (else)
+    #:datum-literals (unix)
+    [(_ lib-id:id
+        ;; old-style "else", support legacy `system` specs
+        [(unix) unix-lib-expr ...+]
+        [system::system-spec lib ...]
+        ...)
+     #'(define-runtime-lib lib-id
+         [system.modern lib ...]
+         ...
+         [else unix-lib-expr ...])]
+    [(_ f ...)
+     ;; assume modern syntax
+     (syntax/loc stx
+       (define-runtime-lib f ...))]))

--- a/draw-lib/racket/draw/unsafe/cairo-lib.rkt
+++ b/draw-lib/racket/draw/unsafe/cairo-lib.rkt
@@ -7,30 +7,30 @@
          "../private/utils.rkt")
 
 (define-runtime-lib fontconfig-lib
-  [(unix) (ffi-lib "libfontconfig" '("1" ""))]
-  [(macosx)
+  [macosx
    (ffi-lib "libpng16.16.dylib")
    (ffi-lib "libexpat.1.dylib")
    (ffi-lib "libuuid.1.dylib")
    (ffi-lib "libfreetype.6.dylib")
    (ffi-lib "libfontconfig.1.dylib")]
-  [(windows)
+  [windows
    (ffi-lib "zlib1.dll")
    (ffi-lib "libiconv-2.dll")
    (ffi-lib "libintl-9.dll")
    (ffi-lib "libpng16-16.dll")
    (ffi-lib "libexpat-1.dll")
    (ffi-lib "libfreetype-6.dll")
-   (ffi-lib "libfontconfig-1.dll")])
+   (ffi-lib "libfontconfig-1.dll")]
+  [else (ffi-lib "libfontconfig" '("1" ""))])
 
 (define-runtime-lib cairo-lib
-  [(unix) (ffi-lib "libcairo" '("2" ""))]
-  [(macosx)
+  [macosx
    (ffi-lib "libpixman-1.0.dylib")
    (ffi-lib "libcairo.2.dylib")]
-  [(windows)
+  [windows
    (ffi-lib "libpixman-1-0.dll")
-   (ffi-lib "libcairo-2.dll")])
+   (ffi-lib "libcairo-2.dll")]
+  [else (ffi-lib "libcairo" '("2" ""))])
 
 ;; A Racket-specific patch to Fontconfig defines FcSetFallbackDirs(),
 ;; which lets us set default paths to point to a Racket-specific

--- a/draw-lib/racket/draw/unsafe/glib.rkt
+++ b/draw-lib/racket/draw/unsafe/glib.rkt
@@ -10,41 +10,41 @@
           define-gobj))
 
 (define-runtime-lib glib-lib
-  [(unix) (ffi-lib "libglib-2.0" '("0" ""))]
-  [(macosx)
+  [macosx
    (ffi-lib "libintl.9.dylib")
    (ffi-lib "libglib-2.0.0.dylib")]
-  [(windows)
+  [windows
    (ffi-lib "libiconv-2.dll")
    (ffi-lib "libintl-9.dll")
-   (ffi-lib "libglib-2.0-0.dll")])
+   (ffi-lib "libglib-2.0-0.dll")]
+  [else (ffi-lib "libglib-2.0" '("0" ""))])
 
 (define-runtime-lib gmodule-lib
-  [(unix) (ffi-lib "libgmodule-2.0" '("0" ""))]
-  [(macosx)
+  [macosx
    (ffi-lib "libgthread-2.0.0.dylib")
    (ffi-lib "libgmodule-2.0.0.dylib")]
-  [(windows)
+  [windows
    (ffi-lib "libgthread-2.0-0.dll")
-   (ffi-lib "libgmodule-2.0-0.dll")])
+   (ffi-lib "libgmodule-2.0-0.dll")]
+  [else (ffi-lib "libgmodule-2.0" '("0" ""))])
 
 (define-runtime-lib libffi-lib
   ;; needed by libgobject
-  [(unix)
+  [macosx
+   (ffi-lib "libffi.6.dylib")]
+  [windows
+   (ffi-lib "libffi-6.dll")]
+  [else
    ;; If an expected version is not available, then assume it's not
    ;; natipkg, and shared-library search when libgobject is loaded
-   (ffi-lib "libffi" '("6" "7" "8" "") #:fail (lambda () #f))]
-  [(macosx)
-   (ffi-lib "libffi.6.dylib")]
-  [(windows)
-   (ffi-lib "libffi-6.dll")])
+   (ffi-lib "libffi" '("6" "7" "8" "") #:fail (lambda () #f))])
 
 (define-runtime-lib gobj-lib
-  [(unix) (ffi-lib "libgobject-2.0" '("0" ""))]
-  [(macosx)
+  [macosx
    (ffi-lib "libgobject-2.0.0.dylib")]
-  [(windows)
-   (ffi-lib "libgobject-2.0-0.dll")])
+  [windows
+   (ffi-lib "libgobject-2.0-0.dll")]
+  [else (ffi-lib "libgobject-2.0" '("0" ""))])
 
 (define-ffi-definer define-glib glib-lib)
 (define-ffi-definer define-gmodule gmodule-lib)

--- a/draw-lib/racket/draw/unsafe/jpeg.rkt
+++ b/draw-lib/racket/draw/unsafe/jpeg.rkt
@@ -7,9 +7,9 @@
          "callback.rkt")
 
 (define-runtime-lib jpeg-lib
-  [(unix) (ffi-lib "libjpeg" '("62" "8" "9" ""))]
-  [(macosx) (ffi-lib "libjpeg.9.dylib")]
-  [(windows) (ffi-lib "libjpeg-9.dll")])
+  [macosx (ffi-lib "libjpeg.9.dylib")]
+  [windows (ffi-lib "libjpeg-9.dll")]
+  [else (ffi-lib "libjpeg" '("62" "8" "9" ""))])
 
 (define-ffi-definer define-jpeg jpeg-lib
   #:provide provide)

--- a/draw-lib/racket/draw/unsafe/pango.rkt
+++ b/draw-lib/racket/draw/unsafe/pango.rkt
@@ -8,27 +8,26 @@
          "../private/libs.rkt")
 
 (define-runtime-lib pango-lib
-  [(unix) (ffi-lib "libpango-1.0" '("0" ""))]
-  [(macosx)
+  [macosx
    (ffi-lib "libfribidi.0.dylib")
    (ffi-lib "libpango-1.0.0.dylib")]
-  [(windows)
+  [windows
    (ffi-lib "libfribidi-0.dll")
-   (ffi-lib "libpango-1.0-0.dll")])
+   (ffi-lib "libpango-1.0-0.dll")]
+  [else (ffi-lib "libpango-1.0" '("0" ""))])
 
 (define-runtime-lib pangowin32-lib
-  [(unix) #f]
-  [(macosx)]
-  [(windows)
-   (ffi-lib "libpangowin32-1.0-0.dll")])
+  [macosx]
+  [windows
+   (ffi-lib "libpangowin32-1.0-0.dll")]
+  [else #f])
 
 (define-runtime-lib pangocairo-lib
-  [(unix) (ffi-lib "libpangocairo-1.0" '("0" ""))]
-  [(macosx)
+  [macosx
    (ffi-lib "libharfbuzz.0.dylib")
    (ffi-lib "libpangoft2-1.0.0.dylib")
    (ffi-lib "libpangocairo-1.0.0.dylib")]
-  [(windows)
+  [windows
    (ffi-lib "libiconv-2.dll")
    (ffi-lib "libintl-9.dll")
    (ffi-lib "libpangowin32-1.0-0.dll")
@@ -37,7 +36,8 @@
    (ffi-lib "libfontconfig-1.dll")
    (ffi-lib "libharfbuzz-0.dll")
    (ffi-lib "libpangoft2-1.0-0.dll")
-   (ffi-lib "libpangocairo-1.0-0.dll")])
+   (ffi-lib "libpangocairo-1.0-0.dll")]
+  [else (ffi-lib "libpangocairo-1.0" '("0" ""))])
 
 (define-ffi-definer define-pango pango-lib
   #:provide provide)

--- a/draw-lib/racket/draw/unsafe/png.rkt
+++ b/draw-lib/racket/draw/unsafe/png.rkt
@@ -7,7 +7,11 @@
          "callback.rkt")
 
 (define-runtime-lib png-lib
-  [(unix)
+  [macosx (ffi-lib "libpng16.16.dylib")]
+  [windows
+   (ffi-lib "zlib1.dll")
+   (ffi-lib "libpng16-16.dll")]
+  [else
    ;; Most Linux distros supply "libpng12", while other Unix
    ;; variants often have just "libpng", etc.
    (let loop ([alts '(("libpng16" ("16" ""))
@@ -17,11 +21,7 @@
       [(null? alts) (ffi-lib "libpng")]
       [else (apply ffi-lib (car alts)
                    #:fail (lambda ()
-                            (loop (cdr alts))))]))]
-  [(macosx) (ffi-lib "libpng16.16.dylib")]
-  [(windows)
-   (ffi-lib "zlib1.dll")
-   (ffi-lib "libpng16-16.dll")])
+                            (loop (cdr alts))))]))])
 
 (define-ffi-definer define-png png-lib
   #:provide provide)


### PR DESCRIPTION
Change `define-runtime-lib` from `racket/draw/private/utils/libs` to use the new `ffi/unsafe/runtime-lib` (racket/racket#5538).