### PR TITLE
Expose Pango libraries via racket/draw/unsafe/pango-lib

### DIFF
--- a/draw-doc/scribblings/draw/unsafe.scrbl
+++ b/draw-doc/scribblings/draw/unsafe.scrbl
@@ -57,4 +57,21 @@ surface is effectively converted to a stipple bitmap for the result datum.}
 A reference to the Cairo library for use with functions such as
 @racket[get-ffi-obj], or @racket[#f] if Cairo is unavailable.}
 
+@section{Pango Library}
 
+@defmodule[racket/draw/unsafe/pango-lib]
+
+@defthing*[([pango-lib ffi-lib?]
+            [pangocairo-lib ffi-lib?])]{
+
+References to the Pango and PangoCairo libraries for use with functions
+such as @racket[get-ffi-obj].
+
+@history[#:added "1.25"]}
+
+@defthing[pangowin32-lib (or/c ffi-lib? #f)]{
+
+A reference to the Pango Win32 library for use with functions such as
+@racket[get-ffi-obj], or @racket[#f] on non-Windows platforms.
+
+@history[#:added "1.25"]}

--- a/draw-lib/info.rkt
+++ b/draw-lib/info.rkt
@@ -22,7 +22,7 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.24")
+(define version "1.25")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/draw-lib/racket/draw/unsafe/pango-lib.rkt
+++ b/draw-lib/racket/draw/unsafe/pango-lib.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+(require ffi/unsafe
+	 ffi/unsafe/runtime-lib)
+
+(provide (protect-out pango-lib
+                      pangowin32-lib
+                      pangocairo-lib))
+
+(define-runtime-lib pango-lib
+  [macosx
+   (so "libfribidi.0.dylib")
+   (so "libpango-1.0.0.dylib")]
+  [(and windows 64)
+   (so "gio-2.0-0.dll")
+   (so "fribidi-0.dll")
+   (so "harfbuzz.dll")
+   (so "pango-1.0-0.dll")]
+  [windows
+   (so "libfribidi-0.dll")
+   (so "libpango-1.0-0.dll")]
+  [else (ffi-lib "libpango-1.0" '("0" ""))])
+
+(define-runtime-lib pangowin32-lib
+  [macosx]
+  [(and windows 64)
+   (so "pangowin32-1.0-0.dll")]
+  [windows
+   (so "libpangowin32-1.0-0.dll")]
+  [else #f])
+
+(define-runtime-lib pangocairo-lib
+  [macosx
+   (so "libharfbuzz.0.dylib")
+   (so "libpangoft2-1.0.0.dylib")
+   (so "libpangocairo-1.0.0.dylib")]
+  [(and windows 64)
+   (so "pangoft2-1.0-0.dll")
+   (so "pangocairo-1.0-0.dll")]
+  [windows
+   (so "libharfbuzz-0.dll")
+   (so "libpangoft2-1.0-0.dll")
+   (so "libpangocairo-1.0-0.dll")]
+  [else (ffi-lib "libpangocairo-1.0" '("0" ""))])

--- a/draw-lib/racket/draw/unsafe/pango.rkt
+++ b/draw-lib/racket/draw/unsafe/pango.rkt
@@ -5,43 +5,8 @@
 	 ffi/unsafe/runtime-lib
          "glib.rkt"
          "cairo.rkt"
+         "pango-lib.rkt"
          "../private/utils.rkt")
-
-(define-runtime-lib pango-lib
-  [macosx
-   (so "libfribidi.0.dylib")
-   (so "libpango-1.0.0.dylib")]
-  [(and windows 64)
-   (so "gio-2.0-0.dll")
-   (so "fribidi-0.dll")
-   (so "harfbuzz.dll")
-   (so "pango-1.0-0.dll")]
-  [windows
-   (so "libfribidi-0.dll")
-   (so "libpango-1.0-0.dll")]
-  [else (ffi-lib "libpango-1.0" '("0" ""))])
-
-(define-runtime-lib pangowin32-lib
-  [macosx]
-  [(and windows 64)
-   (so "pangowin32-1.0-0.dll")]
-  [windows
-   (so "libpangowin32-1.0-0.dll")]
-  [else #f])
-
-(define-runtime-lib pangocairo-lib
-  [macosx
-   (so "libharfbuzz.0.dylib")
-   (so "libpangoft2-1.0.0.dylib")
-   (so "libpangocairo-1.0.0.dylib")]
-  [(and windows 64)
-   (so "pangoft2-1.0-0.dll")
-   (so "pangocairo-1.0-0.dll")]
-  [windows
-   (so "libharfbuzz-0.dll")
-   (so "libpangoft2-1.0-0.dll")
-   (so "libpangocairo-1.0-0.dll")]
-  [else (ffi-lib "libpangocairo-1.0" '("0" ""))])
 
 (define-ffi-definer define-pango pango-lib
   #:provide provide)


### PR DESCRIPTION
This is analogous to the existing `racket/private/draw/cairo-lib` but for Pango libraries.